### PR TITLE
Feature/watch multi tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.8.3           
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get
+      - run: make test

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ Keel provides several key features:
 
 * __[DockerHub Webhooks](https://docs.docker.com/docker-hub/webhooks/) support__ - Keel accepts dockerhub style webhooks on `/v1/webhooks/dockerhub` endpoint. Impacted deployments will be identified and updated.
 
-*  __[Polling](https://keel.sh/user-guide/#polling-deployment-example)__ - when webhooks and pubsub aren't available - Keel can still be useful by checking Docker Registry for changed SHA digest.
+*  __[Polling](https://keel.sh/user-guide/#polling-deployment-example)__ - when webhooks and pubsub aren't available - Keel can still be useful by checking Docker Registry for new tags (if current tag is semver) or same tag SHA digest change (ie: `latest`).
 
 * __Notifications__ - out of the box Keel has Slack and standard webhook notifications, more info [here](https://keel.sh/user-guide/#notifications)
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -36,6 +36,11 @@ type Opts struct {
 	Username, Password  string // if "" - anonymous
 }
 
+// LogFormatter - formatter callback passed into registry client
+func LogFormatter(format string, args ...interface{}) {
+	log.Debugf(format, args...)
+}
+
 // Get - get repository
 func (c *DefaultClient) Get(opts Opts) (*Repository, error) {
 
@@ -44,6 +49,7 @@ func (c *DefaultClient) Get(opts Opts) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
+	hub.Logf = LogFormatter
 
 	tags, err := hub.Tags(opts.Name)
 	if err != nil {
@@ -70,6 +76,7 @@ func (c *DefaultClient) Digest(opts Opts) (digest string, err error) {
 	if err != nil {
 		return
 	}
+	hub.Logf = LogFormatter
 
 	manifestDigest, err := hub.ManifestDigest(opts.Name, opts.Tag)
 	if err != nil {

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -160,3 +160,30 @@ func TestWatchAllTagsJob(t *testing.T) {
 		t.Errorf("expected event repository tag 1.1.3, but got: %s", submitted.Repository.Tag)
 	}
 }
+
+func TestWatchAllTagsJobCurrentLatest(t *testing.T) {
+
+	fp := &fakeProvider{}
+	providers := provider.New([]provider.Provider{fp})
+
+	frc := &fakeRegistryClient{
+		tagsToReturn: []string{"1.1.2", "1.1.3", "0.9.1"},
+	}
+
+	reference, _ := image.Parse("foo/bar:latest")
+
+	details := &watchDetails{
+		imageRef: reference,
+	}
+
+	job := NewWatchRepositoryTagsJob(providers, frc, details)
+
+	job.Run()
+
+	// checking whether new job was submitted
+
+	if len(fp.submitted) != 0 {
+		t.Errorf("expected 0 submitted events but got something: %s", fp.submitted[0].Repository)
+	}
+
+}

--- a/trigger/poll/watcher_test.go
+++ b/trigger/poll/watcher_test.go
@@ -14,10 +14,15 @@ type fakeRegistryClient struct {
 	opts registry.Opts // opts set if anything called Digest(opts Opts)
 
 	digestToReturn string
+
+	tagsToReturn []string
 }
 
 func (c *fakeRegistryClient) Get(opts registry.Opts) (*registry.Repository, error) {
-	return nil, nil
+	return &registry.Repository{
+		Name: opts.Name,
+		Tags: c.tagsToReturn,
+	}, nil
 }
 
 func (c *fakeRegistryClient) Digest(opts registry.Opts) (digest string, err error) {
@@ -62,7 +67,7 @@ func TestWatchTagJob(t *testing.T) {
 
 	submitted := fp.submitted[0]
 
-	if submitted.Repository.Name != "index.docker.io/foo/bar:1.1" {
+	if submitted.Repository.Name != "index.docker.io/foo/bar" {
 		t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
 	}
 
@@ -105,7 +110,7 @@ func TestWatchTagJobLatest(t *testing.T) {
 
 	submitted := fp.submitted[0]
 
-	if submitted.Repository.Name != "index.docker.io/foo/bar:latest" {
+	if submitted.Repository.Name != "index.docker.io/foo/bar" {
 		t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
 	}
 
@@ -121,5 +126,37 @@ func TestWatchTagJobLatest(t *testing.T) {
 
 	if job.details.digest != frc.digestToReturn {
 		t.Errorf("job details digest wasn't updated")
+	}
+}
+
+func TestWatchAllTagsJob(t *testing.T) {
+
+	fp := &fakeProvider{}
+	providers := provider.New([]provider.Provider{fp})
+
+	frc := &fakeRegistryClient{
+		tagsToReturn: []string{"1.1.2", "1.1.3", "0.9.1"},
+	}
+
+	reference, _ := image.Parse("foo/bar:1.1.0")
+
+	details := &watchDetails{
+		imageRef: reference,
+	}
+
+	job := NewWatchRepositoryTagsJob(providers, frc, details)
+
+	job.Run()
+
+	// checking whether new job was submitted
+
+	submitted := fp.submitted[0]
+
+	if submitted.Repository.Name != "index.docker.io/foo/bar" {
+		t.Errorf("unexpected event repository name: %s", submitted.Repository.Name)
+	}
+
+	if submitted.Repository.Tag != "1.1.3" {
+		t.Errorf("expected event repository tag 1.1.3, but got: %s", submitted.Repository.Tag)
 	}
 }

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -15,11 +15,18 @@ import (
 // ErrVersionTagMissing - tag missing error
 var ErrVersionTagMissing = errors.New("version tag is missing")
 
+// ErrInvalidSemVer is returned a version is found to be invalid when
+// being parsed.
+var ErrInvalidSemVer = errors.New("invalid semantic version")
+
 // GetVersion - parse version
 func GetVersion(version string) (*types.Version, error) {
 
 	v, err := semver.NewVersion(version)
 	if err != nil {
+		if err == semver.ErrInvalidSemVer {
+			return nil, ErrInvalidSemVer
+		}
 		return nil, err
 	}
 	// TODO: probably make it customazible
@@ -83,7 +90,7 @@ func NewAvailable(current string, tags []string) (newVersion string, newAvailabl
 			log.WithFields(log.Fields{
 				"error": err,
 				"tag":   r,
-			}).Error("failed to parse tag")
+			}).Debug("failed to parse tag")
 			continue
 
 		}
@@ -92,7 +99,7 @@ func NewAvailable(current string, tags []string) (newVersion string, newAvailabl
 	}
 
 	if len(vs) == 0 {
-		log.Error("no versions available")
+		log.Debug("no versions available")
 		return "", false, nil
 	}
 

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -3,10 +3,13 @@ package version
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/rusenask/keel/types"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // ErrVersionTagMissing - tag missing error
@@ -58,6 +61,47 @@ func GetImageNameAndVersion(name string) (string, *types.Version, error) {
 	}
 
 	return "", nil, ErrVersionTagMissing
+}
+
+// NewAvailable - takes version and current tags. Checks whether there is a new version in the list of tags
+// and returns it as well as newAvailable bool
+func NewAvailable(current string, tags []string) (newVersion string, newAvailable bool, err error) {
+
+	currentVersion, err := semver.NewVersion(current)
+	if err != nil {
+		return "", false, err
+	}
+
+	if len(tags) == 0 {
+		return "", false, nil
+	}
+
+	var vs []*semver.Version
+	for _, r := range tags {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+				"tag":   r,
+			}).Error("failed to parse tag")
+			continue
+
+		}
+
+		vs = append(vs, v)
+	}
+
+	if len(vs) == 0 {
+		log.Error("no versions available")
+		return "", false, nil
+	}
+
+	sort.Sort(sort.Reverse(semver.Collection(vs)))
+
+	if currentVersion.LessThan(vs[0]) {
+		return vs[0].String(), true, nil
+	}
+	return "", false, nil
 }
 
 // ShouldUpdate - checks whether update is needed

--- a/util/version/version_test.go
+++ b/util/version/version_test.go
@@ -176,3 +176,82 @@ func TestShouldUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestNewAvailable(t *testing.T) {
+	type args struct {
+		current string
+		tags    []string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantNewVersion   string
+		wantNewAvailable bool
+		wantErr          bool
+	}{
+		{
+			name:             "new semver",
+			args:             args{current: "1.1.1", tags: []string{"1.1.1", "1.1.2"}},
+			wantNewVersion:   "1.1.2",
+			wantNewAvailable: true,
+			wantErr:          false,
+		},
+		{
+			name:             "no new semver",
+			args:             args{current: "1.1.1", tags: []string{"1.1.0", "1.1.1"}},
+			wantNewVersion:   "",
+			wantNewAvailable: false,
+			wantErr:          false,
+		},
+		{
+			name:             "no semvers in tag list",
+			args:             args{current: "1.1.1", tags: []string{"latest", "alpha"}},
+			wantNewVersion:   "",
+			wantNewAvailable: false,
+			wantErr:          false,
+		},
+		{
+			name:             "mixed tag list",
+			args:             args{current: "1.1.1", tags: []string{"latest", "alpha", "1.1.2"}},
+			wantNewVersion:   "1.1.2",
+			wantNewAvailable: true,
+			wantErr:          false,
+		},
+		{
+			name:             "mixed tag list",
+			args:             args{current: "1.1.1", tags: []string{"1.1.0", "alpha", "1.1.2", "latest"}},
+			wantNewVersion:   "1.1.2",
+			wantNewAvailable: true,
+			wantErr:          false,
+		},
+		{
+			name:             "empty tags list",
+			args:             args{current: "1.1.1", tags: []string{}},
+			wantNewVersion:   "",
+			wantNewAvailable: false,
+			wantErr:          false,
+		},
+		{
+			name:             "not semver current tag",
+			args:             args{current: "latest", tags: []string{"1.1.1"}},
+			wantNewVersion:   "",
+			wantNewAvailable: false,
+			wantErr:          true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNewVersion, gotNewAvailable, err := NewAvailable(tt.args.current, tt.args.tags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewAvailable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotNewVersion != tt.wantNewVersion {
+				t.Errorf("NewAvailable() gotNewVersion = %v, want %v", gotNewVersion, tt.wantNewVersion)
+			}
+			if gotNewAvailable != tt.wantNewAvailable {
+				t.Errorf("NewAvailable() gotNewAvailable = %v, want %v", gotNewAvailable, tt.wantNewAvailable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
added semver support for polling trigger.
If it detects deployment with ie: `0.1.1` version and in the registry it finds `0.1.2` - it will trigger an event so deployers can bump version (if policy matches)