### PR TITLE
Remove redundant version check and unit test case

### DIFF
--- a/util/version/version.go
+++ b/util/version/version.go
@@ -137,7 +137,7 @@ func ShouldUpdate(current *types.Version, new *types.Version, policy types.Polic
 	case types.PolicyTypeMinor:
 		return newVersion.Major() == currentVersion.Major(), nil
 	case types.PolicyTypePatch:
-		return newVersion.Major() == currentVersion.Major() && newVersion.Minor() == currentVersion.Minor() && newVersion.Patch() > currentVersion.Patch(), nil
+		return newVersion.Major() == currentVersion.Major() && newVersion.Minor() == currentVersion.Minor(), nil
 	}
 	return false, nil
 }

--- a/util/version/version_test.go
+++ b/util/version/version_test.go
@@ -133,6 +133,16 @@ func TestShouldUpdate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "patch decrease, policy patch",
+			args: args{
+				current: &types.Version{Major: 1, Minor: 4, Patch: 5},
+				new:     &types.Version{Major: 1, Minor: 4, Patch: 4},
+				policy:  types.PolicyTypePatch,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
 			name: "patch AND major increase, policy patch",
 			args: args{
 				current: &types.Version{Major: 1, Minor: 4, Patch: 5},
@@ -168,16 +178,6 @@ func TestShouldUpdate(t *testing.T) {
 				current: &types.Version{Major: 1, Minor: 4, Patch: 5},
 				new:     &types.Version{Major: 1, Minor: 4, Patch: 6},
 				policy:  types.PolicyTypeMinor,
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "patch increase, policy ptach",
-			args: args{
-				current: &types.Version{Major: 1, Minor: 4, Patch: 5},
-				new:     &types.Version{Major: 1, Minor: 4, Patch: 6},
-				policy:  types.PolicyTypePatch,
 			},
 			want:    true,
 			wantErr: false,


### PR DESCRIPTION
This change introduces some small fixes for the `util/version` package of
`keel`. There should be no breaking changes introduced by the changes being
proposed.

The first change is around the version check when the policy is set to
PolicyTypePatch. In this path, the major and minor versions are confirmed to be
the same. It then checks to make sure the new patch is greater than the current
one, which we already do here:

* https://github.com/theckman/keel/blob/b3ba3a47f1c9e0f4fc93571645286aacf00b4d39/util/version/version.go#L129-L132

This change removes the check confirming that the patch is higher on the new
version. An additional test was added to test for a patch decrease, with
PolicyTypePatch, to make sure nothing was broken.

Lastly, in the process of writing this test a duplicated test case was
discovered in the test file so it was removed.

Signed-off-by: Tim Heckman <t@heckman.io>

This PR is the same as #62, but is instead opened against the `develop` branch.