### PR TITLE
Use the original tag not the SemVer-ified one

### DIFF
--- a/util/version/version.go
+++ b/util/version/version.go
@@ -110,7 +110,7 @@ func NewAvailable(current string, tags []string) (newVersion string, newAvailabl
 	sort.Sort(sort.Reverse(semver.Collection(vs)))
 
 	if currentVersion.LessThan(vs[0]) {
-		return vs[0].String(), true, nil
+		return vs[0].Original(), true, nil
 	}
 	return "", false, nil
 }

--- a/util/version/version_test.go
+++ b/util/version/version_test.go
@@ -276,6 +276,13 @@ func TestNewAvailable(t *testing.T) {
 			wantNewAvailable: true,
 			wantErr:          false,
 		},
+		{
+			name:             "simple semver",
+			args:             args{current: "8.1", tags: []string{"8.1", "8.2", "8.3"}},
+			wantNewVersion:   "8.3",
+			wantNewAvailable: true,
+			wantErr:          false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
For example trailing 0 are added on parse and used for validation but may be missing from the tag.

So if you had images 8.1, 8.2, 8.3 when SemVer compares it does so with 8.1.0, 8.2.0 but the image will still be 8.2 so that is what needs to be updated.