### PR TITLE
Feature/notification levels

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -15,3 +15,6 @@ const (
 	EnvSlackBotName  = "SLACK_BOT_NAME"
 	EnvSlackChannels = "SLACK_CHANNELS"
 )
+
+// EnvNotificationLevel - minimum level for notifications, defaults to info
+const EnvNotificationLevel = "NOTIFICATION_LEVEL"

--- a/extension/notification/notification.go
+++ b/extension/notification/notification.go
@@ -32,6 +32,7 @@ var (
 // notifiers.
 type Config struct {
 	Attempts int
+	Level    types.Level
 	Params   map[string]interface{} `yaml:",inline"`
 }
 
@@ -76,6 +77,7 @@ func RegisterSender(name string, s Sender) {
 type DefaultNotificationSender struct {
 	config  *Config
 	stopper *stopper.Stopper
+	level   types.Level
 }
 
 // New - create new sender
@@ -118,6 +120,10 @@ func (m *DefaultNotificationSender) Senders() map[string]Sender {
 
 // Send - send notifications through all configured senders
 func (m *DefaultNotificationSender) Send(event types.EventNotification) error {
+	if event.Level < m.config.Level {
+		return nil
+	}
+
 	sendersM.RLock()
 	defer sendersM.RUnlock()
 

--- a/extension/notification/notification_test.go
+++ b/extension/notification/notification_test.go
@@ -1,0 +1,129 @@
+package notification
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rusenask/keel/types"
+)
+
+type fakeSender struct {
+	sent *types.EventNotification
+
+	shouldConfigure bool
+	shouldError     error
+}
+
+func (s *fakeSender) Configure(*Config) (bool, error) {
+	return s.shouldConfigure, nil
+}
+
+func (s *fakeSender) Send(event types.EventNotification) error {
+	s.sent = &event
+	fmt.Println("sending event")
+	return s.shouldError
+}
+
+func TestSend(t *testing.T) {
+	sndr := New(context.Background())
+
+	sndr.Configure(&Config{
+		Level:    types.LevelDebug,
+		Attempts: 1,
+	})
+
+	fs := &fakeSender{
+		shouldConfigure: true,
+		shouldError:     nil,
+	}
+
+	RegisterSender("fakeSender", fs)
+	defer sndr.UnregisterSender("fakeSender")
+
+	err := sndr.Send(types.EventNotification{
+		Level:   types.LevelInfo,
+		Type:    types.NotificationPreDeploymentUpdate,
+		Message: "foo",
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if fs.sent.Message != "foo" {
+		t.Errorf("unexpected notification message: %s", fs.sent.Message)
+	}
+
+	if fs.sent.Level != types.LevelInfo {
+		t.Errorf("unexpected level: %s", fs.sent.Level)
+	}
+}
+
+// test when configured level is higher than the event
+func TestSendLevelNotificationA(t *testing.T) {
+	sndr := New(context.Background())
+
+	sndr.Configure(&Config{
+		Level:    types.LevelInfo,
+		Attempts: 1,
+	})
+
+	fs := &fakeSender{
+		shouldConfigure: true,
+		shouldError:     nil,
+	}
+
+	RegisterSender("fakeSender", fs)
+	defer sndr.UnregisterSender("fakeSender")
+
+	err := sndr.Send(types.EventNotification{
+		Level:   types.LevelDebug,
+		Type:    types.NotificationPreDeploymentUpdate,
+		Message: "foo",
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if fs.sent != nil {
+		t.Errorf("didn't expect to find sent even for this level")
+	}
+}
+
+// event level is higher than the configured
+func TestSendLevelNotificationB(t *testing.T) {
+	sndr := New(context.Background())
+
+	sndr.Configure(&Config{
+		Level:    types.LevelInfo,
+		Attempts: 1,
+	})
+
+	fs := &fakeSender{
+		shouldConfigure: true,
+		shouldError:     nil,
+	}
+
+	RegisterSender("fakeSender", fs)
+	defer sndr.UnregisterSender("fakeSender")
+
+	err := sndr.Send(types.EventNotification{
+		Level:   types.LevelSuccess,
+		Type:    types.NotificationPreDeploymentUpdate,
+		Message: "foo",
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if fs.sent.Message != "foo" {
+		t.Errorf("unexpected notification message: %s", fs.sent.Message)
+	}
+
+	if fs.sent.Level != types.LevelSuccess {
+		t.Errorf("unexpected level: %s", fs.sent.Level)
+	}
+}

--- a/extension/notification/webhook/webhook_test.go
+++ b/extension/notification/webhook/webhook_test.go
@@ -25,7 +25,7 @@ func TestWebhookRequest(t *testing.T) {
 			t.Errorf("missing deployment type")
 		}
 
-		if !strings.Contains(bodyStr, "LevelDebug") {
+		if !strings.Contains(bodyStr, "debug") {
 			t.Errorf("missing level")
 		}
 

--- a/main.go
+++ b/main.go
@@ -74,8 +74,21 @@ func main() {
 	ctx, cancel := netContext.WithCancel(context.Background())
 	defer cancel()
 
+	notificationLevel := types.LevelInfo
+	if os.Getenv(constants.EnvNotificationLevel) != "" {
+		parsedLevel, err := types.ParseLevel(os.Getenv(constants.EnvNotificationLevel))
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+			}).Errorf("main: got error while parsing notification level, defaulting to: %s", notificationLevel)
+		} else {
+			notificationLevel = parsedLevel
+		}
+	}
+
 	notifCfg := &notification.Config{
 		Attempts: 10,
+		Level:    notificationLevel,
 	}
 	sender := notification.New(ctx)
 

--- a/types/types.go
+++ b/types/types.go
@@ -9,6 +9,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -223,6 +224,46 @@ const (
 	LevelError
 	LevelFatal
 )
+
+// ParseLevel takes a string level and returns notification level constant.
+func ParseLevel(lvl string) (Level, error) {
+	switch strings.ToLower(lvl) {
+	case "fatal":
+		return LevelFatal, nil
+	case "error":
+		return LevelError, nil
+	case "warn", "warning":
+		return LevelWarn, nil
+	case "info":
+		return LevelInfo, nil
+	case "success":
+		return LevelSuccess, nil
+	case "debug":
+		return LevelDebug, nil
+	}
+
+	var l Level
+	return l, fmt.Errorf("not a valid notification Level: %q", lvl)
+}
+
+func (l Level) String() string {
+	switch l {
+	case LevelDebug:
+		return "debug"
+	case LevelInfo:
+		return "info"
+	case LevelSuccess:
+		return "success"
+	case LevelWarn:
+		return "warn"
+	case LevelError:
+		return "error"
+	case LevelFatal:
+		return "fatal"
+	default:
+		return "unknown"
+	}
+}
 
 // Color - used to assign different colors for events
 func (l Level) Color() string {


### PR DESCRIPTION
Added:
* Ability to set notification levels via `NOTIFICATION_LEVEL` env variable, available levels: debug, info, success, warn, error, fatal (https://github.com/rusenask/keel/issues/101)
* Support for dockerconfigjson format secrets (https://github.com/rusenask/keel/issues/100, https://github.com/rusenask/keel/issues/104)